### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/nanfotGithub/657887c2-10fb-40d3-a600-c7468f5efb68/beb25a4d-9b35-4659-81a8-983c28b05f67/_apis/work/boardbadge/7e8188bc-250c-4844-a26a-456b495c93eb)](https://dev.azure.com/nanfotGithub/657887c2-10fb-40d3-a600-c7468f5efb68/_boards/board/t/beb25a4d-9b35-4659-81a8-983c28b05f67/Microsoft.RequirementCategory)
 # CursoNanfotrGit
  PaginaWebNafor de Git Hub


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3](https://dev.azure.com/nanfotGithub/657887c2-10fb-40d3-a600-c7468f5efb68/_workitems/edit/3). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.